### PR TITLE
Add help bubble to project pages

### DIFF
--- a/app/features/common-components/HelpBubble.tsx
+++ b/app/features/common-components/HelpBubble.tsx
@@ -1,0 +1,13 @@
+"use client";
+import React from 'react';
+
+export const HelpBubble: React.FC = () => {
+  return (
+    <a
+      href="sms:+13322507372"
+      className="fixed bottom-4 right-4 bg-gradient-to-r from-[#69D998] to-[#09ac9c] dark:from-[#69D998] dark:to-[#2be8d5] text-white py-2 px-4 rounded-full shadow-lg z-50 text-sm hover:opacity-90"
+    >
+      Need help? Text now: (332)-250-7372
+    </a>
+  );
+};

--- a/app/features/project-creation/page.tsx
+++ b/app/features/project-creation/page.tsx
@@ -8,6 +8,7 @@ import ProjectCreationForm from "./components/ProjectCreationForm";
 // import { Logo } from "../common-components/Logo";
 import { Footer } from "../common-components/Footer";
 import FallbackBanner from "../common-components/FallbackBanner";
+import { HelpBubble } from "../common-components/HelpBubble";
 
 export default function ProjectCreationPage() {
   const [isDark, setIsDark] = useState(false);
@@ -65,6 +66,7 @@ export default function ProjectCreationPage() {
       </main>
 
       <Footer />
+      <HelpBubble />
     </div>
   );
 }

--- a/app/features/survey-booking/page.tsx
+++ b/app/features/survey-booking/page.tsx
@@ -7,6 +7,7 @@ import { Ribbon } from "../common-components/Ribbon";
 import { CentralBlock } from "../common-components/CentralBlock";
 import Image from "next/image";
 import { Footer } from "../common-components/Footer";
+import { HelpBubble } from "../common-components/HelpBubble";
 
 // Extract search params logic to a client component
 function SearchParamsHandler() {
@@ -87,6 +88,7 @@ export default function SurveyBookingPage() {
       
       <div className="w-full">
         <Footer />
+        <HelpBubble />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add HelpBubble component
- show HelpBubble on project creation and survey booking pages

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ebdc5108333be44db53a4198c0f