### PR TITLE
Add help bubble to project pages

### DIFF
--- a/app/features/common-components/HelpBubble.tsx
+++ b/app/features/common-components/HelpBubble.tsx
@@ -1,0 +1,15 @@
+"use client";
+import React from 'react';
+import { FaSms } from 'react-icons/fa';
+
+export const HelpBubble: React.FC = () => {
+  return (
+    <a
+      href="sms:+13322507372"
+      className="fixed bottom-4 right-4 bg-gradient-to-r from-[#69D998] to-[#09ac9c] dark:from-[#69D998] dark:to-[#2be8d5] text-white py-2 px-4 rounded-full shadow-lg z-50 text-sm hover:opacity-90 flex items-center"
+    >
+      <FaSms className="mr-2" />
+      Need help? Text now: (332)-250-7372
+    </a>
+  );
+};

--- a/app/features/project-creation/components/FinanceTypeSelector.tsx
+++ b/app/features/project-creation/components/FinanceTypeSelector.tsx
@@ -38,7 +38,7 @@ export const FinanceTypeSelector: React.FC<FinanceTypeSelectorProps> = ({
               value={type.id}
               checked={selectedType === type.id}
               onChange={(e) => onChange(e.target.value as FinanceType)}
-              className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4"
+              className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6"
             />
             <span className="text-gray-700 dark:text-gray-200">{type.label}</span>
           </label>

--- a/app/features/project-creation/components/ProjectCreationForm.tsx
+++ b/app/features/project-creation/components/ProjectCreationForm.tsx
@@ -10,6 +10,7 @@ import { useProjectSubmission } from "../hooks/useProjectSubmission";
 import { SubmitButton } from "../../survey-booking/components/common/SubmitButton";
 import { toast } from "react-toastify";
 import ClientOnly from "@/app/components/ClientOnly";
+import { FaClipboardList } from "react-icons/fa";
 
 // Add LanguageSelector component
 const LanguageSelector: React.FC<{
@@ -75,7 +76,7 @@ const EscalatorSection: React.FC<{
                 value={escalator}
                 checked={selectedEscalator === escalator}
                 onChange={(e) => onChange(e.target.value)}
-                className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4"
+                className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6"
               />
               <label
                 htmlFor={`escalator-${escalator}`}
@@ -1832,9 +1833,10 @@ function ProjectCreationFormContent() {
       
       {/* Title as the first element */}
       <div className="relative mb-8 pt-10">
-        <h2 className="text-center text-3xl font-bold 
+        <h2 className="flex items-center justify-center gap-2 text-3xl font-bold
                      bg-gradient-to-r from-[#58b37e] to-[#053058] dark:from-[#8efbbc] dark:to-[#1db7e2]
                      bg-clip-text text-transparent pb-2">
+          <FaClipboardList className="text-[#69D998]" />
           Enter Your Project Details
         </h2>
       </div>
@@ -2001,7 +2003,7 @@ function ProjectCreationFormContent() {
                 name="secondary-contact"
                 checked={showSecondaryContact}
                 onChange={() => handleSecondaryContactChange(true)}
-                className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
               />
               <label htmlFor="secondary-contact-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                 Yes
@@ -2014,7 +2016,7 @@ function ProjectCreationFormContent() {
                 name="secondary-contact"
                 checked={!showSecondaryContact}
                 onChange={() => handleSecondaryContactChange(false)}
-                className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
               />
               <label htmlFor="secondary-contact-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                 No
@@ -2270,7 +2272,7 @@ function ProjectCreationFormContent() {
               name="tenants"
               checked={formData.hasTenants === true}
               onChange={() => handleTenantsChange(true)}
-              className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+              className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
             />
             <label htmlFor="tenants-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
               Yes
@@ -2283,7 +2285,7 @@ function ProjectCreationFormContent() {
               name="tenants"
               checked={formData.hasTenants === false}
               onChange={() => handleTenantsChange(false)}
-              className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+              className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
             />
             <label htmlFor="tenants-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
               No
@@ -2487,7 +2489,7 @@ function ProjectCreationFormContent() {
                         ...(newFinanceType === "Cash" ? { financeCompany: "Cash" as FinanceCompany } : {})
                       }));
                     }}
-                    className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                    className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                   />
                   <label htmlFor={`financeType-${type.id}`} className="text-gray-700 dark:text-gray-200 cursor-pointer">
                     {type.label}

--- a/app/features/project-creation/page.tsx
+++ b/app/features/project-creation/page.tsx
@@ -8,6 +8,7 @@ import ProjectCreationForm from "./components/ProjectCreationForm";
 // import { Logo } from "../common-components/Logo";
 import { Footer } from "../common-components/Footer";
 import FallbackBanner from "../common-components/FallbackBanner";
+import { HelpBubble } from "../common-components/HelpBubble";
 
 export default function ProjectCreationPage() {
   const [isDark, setIsDark] = useState(false);
@@ -65,6 +66,7 @@ export default function ProjectCreationPage() {
       </main>
 
       <Footer />
+      <HelpBubble />
     </div>
   );
 }

--- a/app/features/survey-booking/components/SurveyQuestions.tsx
+++ b/app/features/survey-booking/components/SurveyQuestions.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { SurveyFormData } from '../types/FormData';
 import { BatteryNotice } from './home/BatteryNotice';
+import { FaBatteryHalf, FaRegQuestionCircle } from 'react-icons/fa';
 
 interface SurveyQuestionsProps {
   formData: SurveyFormData;
@@ -58,7 +59,8 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                 </div>
               </div>
             )}
-            <h3 className="text-lg font-bold text-gray-800 mb-1">
+            <h3 className="text-lg font-bold text-gray-800 mb-1 flex items-center gap-2">
+              <FaBatteryHalf className="text-[#69D998]" />
               Are we installing any batteries as part of this project?{" "}
               <span className="text-red-500">*</span>
             </h3>
@@ -73,7 +75,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasBatteries-yes"
                   checked={formData.hasBatteries === true}
                   onChange={() => handleRadioChange("hasBatteries", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasBatteries-yes" className="text-gray-700 cursor-pointer">
                   Yes
@@ -86,7 +88,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasBatteries-no"
                   checked={formData.hasBatteries === false}
                   onChange={() => handleRadioChange("hasBatteries", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasBatteries-no" className="text-gray-700 cursor-pointer">
                   No
@@ -117,7 +119,8 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                 </div>
               </div>
             )}
-            <h3 className="text-lg font-bold text-gray-800 mb-1">
+            <h3 className="text-lg font-bold text-gray-800 mb-1 flex items-center gap-2">
+              <FaRegQuestionCircle className="text-[#69D998]" />
               Which design option do you prefer?{" "}
               <span className="text-red-500">*</span>
             </h3>
@@ -134,7 +137,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   onChange={() =>
                     handleRadioChange("designPreference", "bestSunlight", "Design the system for maximum efficiency")
                   }
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="designPreference-sunlight" className="text-gray-700 cursor-pointer">
                   Design the system for maximum efficiency
@@ -149,7 +152,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   onChange={() =>
                     handleRadioChange("designPreference", "matchProposed", "Design the system to match the proposal design as closely as possible")
                   }
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="designPreference-match" className="text-gray-700 cursor-pointer">
                   Design the system to match the proposal design as closely as possible
@@ -192,7 +195,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="isSharedRoof-yes"
                   checked={formData.isSharedRoof === true}
                   onChange={() => handleRadioChange("isSharedRoof", true, "Yes, please place the design system exactly as specified")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="isSharedRoof-yes" className="text-gray-700 cursor-pointer">
                   Yes, please place the design system exactly as specified
@@ -205,7 +208,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="isSharedRoof-no"
                   checked={formData.isSharedRoof === false}
                   onChange={() => handleRadioChange("isSharedRoof", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="isSharedRoof-no" className="text-gray-700 cursor-pointer">
                   No
@@ -252,7 +255,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   onChange={() =>
                     handleRadioChange("hasRecentConstruction", true, "Yes")
                   }
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasRecentConstruction-yes" className="text-gray-700 cursor-pointer">
                   Yes
@@ -267,7 +270,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   onChange={() =>
                     handleRadioChange("hasRecentConstruction", false, "No")
                   }
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasRecentConstruction-no" className="text-gray-700 cursor-pointer">
                   No
@@ -312,7 +315,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasVaultedCeilings-yes"
                   checked={formData.hasVaultedCeilings === true}
                   onChange={() => handleRadioChange("hasVaultedCeilings", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasVaultedCeilings-yes" className="text-gray-700 cursor-pointer">
                   Yes
@@ -325,7 +328,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasVaultedCeilings-no"
                   checked={formData.hasVaultedCeilings === false}
                   onChange={() => handleRadioChange("hasVaultedCeilings", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasVaultedCeilings-no" className="text-gray-700 cursor-pointer">
                   No
@@ -414,7 +417,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasOngoingConstruction-yes"
                   checked={formData.hasOngoingConstruction === true}
                   onChange={() => handleRadioChange("hasOngoingConstruction", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasOngoingConstruction-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -427,7 +430,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasOngoingConstruction-no"
                   checked={formData.hasOngoingConstruction === false}
                   onChange={() => handleRadioChange("hasOngoingConstruction", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasOngoingConstruction-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -486,7 +489,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasExistingSolar-yes"
                   checked={formData.hasExistingSolar === true}
                   onChange={() => handleRadioChange("hasExistingSolar", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasExistingSolar-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -499,7 +502,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasExistingSolar-no"
                   checked={formData.hasExistingSolar === false}
                   onChange={() => handleRadioChange("hasExistingSolar", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasExistingSolar-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -539,7 +542,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasHOA-yes"
                   checked={formData.hasHOA === true}
                   onChange={() => handleRadioChange("hasHOA", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasHOA-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -552,7 +555,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasHOA-no"
                   checked={formData.hasHOA === false}
                   onChange={() => handleRadioChange("hasHOA", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasHOA-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -608,7 +611,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="mainPanelLocation-inside"
                   checked={formData.mainPanelLocation === "inside"}
                   onChange={() => handleRadioChange("mainPanelLocation", "inside", "Inside the home")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="mainPanelLocation-inside" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Inside the home
@@ -621,7 +624,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="mainPanelLocation-outside"
                   checked={formData.mainPanelLocation === "outside"}
                   onChange={() => handleRadioChange("mainPanelLocation", "outside", "Outside the home")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="mainPanelLocation-outside" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Outside the home
@@ -634,7 +637,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="mainPanelLocation-garage"
                   checked={formData.mainPanelLocation === "garage"}
                   onChange={() => handleRadioChange("mainPanelLocation", "garage", "In the garage")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="mainPanelLocation-garage" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   In the garage
@@ -647,7 +650,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="mainPanelLocation-other"
                   checked={formData.mainPanelLocation === "other"}
                   onChange={() => handleRadioChange("mainPanelLocation", "other", "Other")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="mainPanelLocation-other" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Other
@@ -705,7 +708,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasSubPanels-yes"
                   checked={formData.hasSubPanels === true}
                   onChange={() => handleRadioChange("hasSubPanels", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasSubPanels-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -718,7 +721,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasSubPanels-no"
                   checked={formData.hasSubPanels === false}
                   onChange={() => handleRadioChange("hasSubPanels", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasSubPanels-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -758,7 +761,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasBlockedAccess-yes"
                   checked={formData.hasBlockedAccess === true}
                   onChange={() => handleRadioChange("hasBlockedAccess", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasBlockedAccess-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -771,7 +774,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="hasBlockedAccess-no"
                   checked={formData.hasBlockedAccess === false}
                   onChange={() => handleRadioChange("hasBlockedAccess", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="hasBlockedAccess-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -820,7 +823,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="gateAccessType-yes"
                   checked={formData.gateAccessType === "yes"}
                   onChange={() => handleRadioChange("gateAccessType", "yes", "Yes, I'll be there to provide access")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="gateAccessType-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes, I&apos;ll be there to provide access
@@ -833,7 +836,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="gateAccessType-code"
                   checked={formData.gateAccessType === "code"}
                   onChange={() => handleRadioChange("gateAccessType", "code", "Yes, I have a code")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="gateAccessType-code" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes, I have a code
@@ -846,7 +849,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="gateAccessType-no"
                   checked={formData.gateAccessType === "no"}
                   onChange={() => handleRadioChange("gateAccessType", "no", "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="gateAccessType-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No
@@ -889,7 +892,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="pets-yes"
                   checked={formData.pets === true}
                   onChange={() => handleRadioChange("pets", true, "Yes")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="pets-yes" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   Yes
@@ -902,7 +905,7 @@ export const SurveyQuestions: React.FC<SurveyQuestionsProps> = ({
                   id="pets-no"
                   checked={formData.pets === false}
                   onChange={() => handleRadioChange("pets", false, "No")}
-                  className="form-radio text-blue-600 focus:ring-blue-500 h-4 w-4 mr-2"
+                  className="form-radio text-[#69D998] focus:ring-[#69D998] h-6 w-6 mr-2"
                 />
                 <label htmlFor="pets-no" className="text-gray-700 dark:text-gray-200 cursor-pointer">
                   No

--- a/app/features/survey-booking/page.tsx
+++ b/app/features/survey-booking/page.tsx
@@ -7,6 +7,7 @@ import { Ribbon } from "../common-components/Ribbon";
 import { CentralBlock } from "../common-components/CentralBlock";
 import Image from "next/image";
 import { Footer } from "../common-components/Footer";
+import { HelpBubble } from "../common-components/HelpBubble";
 
 // Extract search params logic to a client component
 function SearchParamsHandler() {
@@ -87,6 +88,7 @@ export default function SurveyBookingPage() {
       
       <div className="w-full">
         <Footer />
+        <HelpBubble />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add phone icon to HelpBubble component
- add clipboard icon to project creation form header
- show battery and design icons on key survey questions

## Testing
- `npm run lint` *(fails to run: interactive prompt)*
- `npm run build` *(fails to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ebdc5108333be44db53a4198c0f